### PR TITLE
c: option to use mmap when given a file name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ scan-c: main.c
 scan-c-fast-simd: main.c
 	$(CC) $(SIMD_CFLAGS) -O3 -DNDEBUG -o $@ $<
 
+scan-c-fast-mmap: main.c
+	$(CC) $(FAST_CFLAGS) -DUSE_MMAP=1 -o $@ $<
+
 scan-c-counters: main.c
 	$(CC) $(SIMD_CFLAGS) -O3 -DDO_INST=1 -o $@ $<
 
@@ -45,6 +48,10 @@ main.s: main.c
 
 time-simd: scan-c-fast-simd
 	time ./scan-c-fast-simd < raw.tar > c.txt
+	diff -q c.txt prev.txt || diff c.txt prev.txt | wc -l
+
+time-mmap: scan-c-fast-mmap
+	time ./scan-c-fast-mmap $(SAMPLE) > c.txt
 	diff -q c.txt prev.txt || diff c.txt prev.txt | wc -l
 
 time: scan-c-fast

--- a/main.c
+++ b/main.c
@@ -27,6 +27,9 @@ limitations under the License.
 #include <stdbool.h>
 #include <stdint.h>
 #include <assert.h>
+#if DO_PAGE_ALIGNED
+#include <stdlib.h>
+#endif
 
 #ifndef DO_INST
     #define DO_INST 0
@@ -365,12 +368,22 @@ static void fd_advise(int fd) {
 }
 
 int main(int argc, const char *argv[]) {
+#if DO_PAGE_ALIGNED
+    int page_size = getpagesize();
+    const size_t MAX_BUF = page_size * 64;
+    unsigned char *buf;
+    if (0 > posix_memalign((void**)&buf, page_size, MAX_BUF)) {
+        perror("memalign");
+        return 20;
+    }
+#else
     // 256k sounds nice.
     // 64*4k pages or 128*2k pages or 512*512b fs blocks
     // small enough for stack allocation
     // small enough to fit in cache on modern CPU
     const size_t MAX_BUF = 64*4096;
     unsigned char buf[MAX_BUF];
+#endif
     int_fast32_t remainder = 0;
     size_t total_read = 0;
     ssize_t nread = 0;


### PR DESCRIPTION
mmap() is supposed to be fast, right? Turns out we skip so aggressively
that the overhead of the extra book keeping and round-tripping with the
kernel that comes with mmap actually ends up costing us more than any
gains.

This is somewhat surprising given that mmap() ends up being a slight
performance boost for ripgrep when dealing with large input files and
that's the specific case I tested with. What I suspect is happening is
that we are skipping so aggressively that the OS hasn't been able to
read the next page for us by the time we finish with the current one.