### PR TITLE
go: adjust buffer size

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ implementations compare to each other.
 |------|------|------|--------|
 | grep | 0m18.034s | 0m15.713s | 0m2.257s |
 | ripgrep | 0m1.709s | 0m1.541s | 0m0.147s |
-| simple (Go) | 0m1.889s | 0m1.679s | 0m0.211s |
+| simple (Go) | 0m1.737s | 0m1.594s | 0m0.142s |
 | simple (Rust) | 0m1.461s | 0m1.325s | 0m0.131s |
 | simple (Node) | 0m6.458s | 0m6.043s | 0m0.627s |
 | custom (C) | **0m0.222s** | **0m0.079s** | **0m0.141s** |

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,7 +24,7 @@ import (
 	"runtime/pprof"
 )
 
-const BUF = 64 * 1024 * 1024
+const BUF = 64 * 4096
 
 func searchWrite(buf []byte, out io.Writer) int {
 	count := 0


### PR DESCRIPTION
Like the rust version, Go sees a small performance boost from switching to 256k buffers for reading.